### PR TITLE
Enhancement/reset tabs

### DIFF
--- a/server.R
+++ b/server.R
@@ -74,6 +74,12 @@ shinyServer(function(input, output, session) {
     #hide tabs in navigation bar
     hide("navbar")
     
+    # Reset the tabs
+    
+    reset("t1_content")
+    
+    reset("t2_content")
+    
   })
   
   ##tab 1###----------------------------------------------------------------------

--- a/server.R
+++ b/server.R
@@ -80,6 +80,9 @@ shinyServer(function(input, output, session) {
     
     reset("t2_content")
     
+    # Ensure Plot tab is selected
+    updateTabsetPanel(session, "t1_tabset", selected = "Plot")
+    
   })
   
   ##tab 1###----------------------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -112,6 +112,8 @@ shinyUI(
   
       tabPanel(
         "Similar Schools",
+        
+        div(id = "t1_content",
         h2("Comparison of Measures to Similiar Schools"),
         sidebarLayout(
           sidebarPanel(
@@ -190,11 +192,12 @@ shinyUI(
               )
             )
           )
-      ),
+      )),
   
   #tab 2 - school to school comparison
       tabPanel(
         "School to School",
+        div(id = "t2_content",
         h2("School to School Comparison of Measures"),
         sidebarLayout(
           sidebarPanel(
@@ -226,5 +229,6 @@ shinyUI(
         )
       )
     )
+  )
   )
 )

--- a/ui.R
+++ b/ui.R
@@ -137,7 +137,7 @@ shinyUI(
           ),
           
           mainPanel(
-            tabsetPanel(
+            tabsetPanel(id = "t1_tabset",
               tabPanel("Plot",
                 br(),
                 fluidRow(


### PR DESCRIPTION
## Background

To resolve #25 

## Steps taken

1. Added in divs as containers for multiple elements and used the shinyjs reset function to reset when change id button is pressed. 
2. Added updatetabsetpanel to select correct tab on plot/data/characteristics sub tab. Without this it doesn't select the Plot tab by default when new school is selected. 