### PR TITLE
Changed FSM variable

### DIFF
--- a/tests/Data/subset_test_data.csv
+++ b/tests/Data/subset_test_data.csv
@@ -8,7 +8,7 @@ URN,characteristics,number_schls
 125667,% pupils that achieved expected for RWM,4854
 125667,Deprivation (IMD score),844
 125667,Selective?,16892
-125715,% pupils eligible for FSM,12908
+125715,% pupils eligible for FSM,15363
 125715,Religious,6171
 126157,Number of pupils (FTE),71
 126157,Ofsted Overall Effectiveness,734
@@ -43,7 +43,7 @@ URN,characteristics,number_schls
 100050,Post-16?,2240
 137915,Number of pupils (FTE),148
 100134,% pupils with SEN support,15370
-139066,% pupils eligible for FSM,9146
+139066,% pupils eligible for FSM,9898
 123447,% pupils with English not as First Language,12386
 100989,Overall Absence Rate %,872
 100023,% pupils that achieved expected for RWM,2347
@@ -57,6 +57,6 @@ URN,characteristics,number_schls
 114519,Ofsted Leadership and Management,11035
 114558,"Pay Band, Ofsted Overall Effectiveness",2454
 138013,"Region, Number of pupils (FTE)",15
-138960,"Local Authority, % pupils eligible for FSM",7
+138960,"Local Authority, % pupils eligible for FSM",67
 100250,"Rurality, School Type",4285
-101106,"Pay Band, Selective?, % pupils eligible for FSM",659
+101106,"Pay Band, Selective?, % pupils eligible for FSM",694

--- a/tests/Data/subset_test_data.csv
+++ b/tests/Data/subset_test_data.csv
@@ -8,7 +8,7 @@ URN,characteristics,number_schls
 125667,% pupils that achieved expected for RWM,4854
 125667,Deprivation (IMD score),844
 125667,Selective?,16892
-125715,% pupils eligible for FSM,15363
+125715,% pupils eligible for FSM,12712
 125715,Religious,6171
 126157,Number of pupils (FTE),71
 126157,Ofsted Overall Effectiveness,734
@@ -43,7 +43,7 @@ URN,characteristics,number_schls
 100050,Post-16?,2240
 137915,Number of pupils (FTE),148
 100134,% pupils with SEN support,15370
-139066,% pupils eligible for FSM,9898
+139066,% pupils eligible for FSM,7706
 123447,% pupils with English not as First Language,12386
 100989,Overall Absence Rate %,872
 100023,% pupils that achieved expected for RWM,2347
@@ -57,6 +57,6 @@ URN,characteristics,number_schls
 114519,Ofsted Leadership and Management,11035
 114558,"Pay Band, Ofsted Overall Effectiveness",2454
 138013,"Region, Number of pupils (FTE)",15
-138960,"Local Authority, % pupils eligible for FSM",67
+138960,"Local Authority, % pupils eligible for FSM",7
 100250,"Rurality, School Type",4285
-101106,"Pay Band, Selective?, % pupils eligible for FSM",694
+101106,"Pay Band, Selective?, % pupils eligible for FSM",541


### PR DESCRIPTION
## **Background**

Get Information About Schools uses '% pupils eligible for FSM (performance tables)' variable so we are making our FSM variable the same for consistency.
To resolve #62 

## **Steps Taken**

1. Changed the variable in the code to generate dataset
2. Re-ran code to generate dataset
3. Re-ran app